### PR TITLE
RetroPlayer: Move GL configuration to ConfigureInternal()

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -39,38 +39,21 @@ RenderBufferPoolVector CRendererFactoryOpenGL::CreateBufferPools(CRenderContext 
 
 // --- CRenderBufferOpenGL -----------------------------------------------------
 
-CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height) :
-  CRenderBufferOpenGLES(context, format, targetFormat, width, height)
+CRenderBufferOpenGL::CRenderBufferOpenGL(CRenderContext &context,
+                                         GLuint pixeltype,
+                                         GLuint internalformat,
+                                         GLuint pixelformat,
+                                         GLuint bpp,
+                                         unsigned int width,
+                                         unsigned int height) :
+  CRenderBufferOpenGLES(context,
+                        pixeltype,
+                        internalformat,
+                        pixelformat,
+                        bpp,
+                        width,
+                        height)
 {
-  switch (m_format)
-  {
-    case AV_PIX_FMT_0RGB32:
-    {
-      m_pixeltype = GL_UNSIGNED_BYTE;
-      m_internalformat = GL_RGBA;
-      m_pixelformat = GL_BGRA;
-      m_bpp = sizeof(uint32_t);
-      break;
-    }
-    case AV_PIX_FMT_RGB555:
-    {
-      m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
-      m_internalformat = GL_RGB;
-      m_pixelformat = GL_RGB;
-      m_bpp = sizeof(uint16_t);
-      break;
-    }
-    case AV_PIX_FMT_RGB565:
-    {
-      m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
-      m_internalformat = GL_RGB;
-      m_pixelformat = GL_RGB;
-      m_bpp = sizeof(uint16_t);
-      break;
-    }
-    default:
-      break; // we shouldn't even get this far if we are given an unsupported pixel format
-  }
 }
 
 bool CRenderBufferOpenGL::UploadTexture()
@@ -100,7 +83,49 @@ CRenderBufferPoolOpenGL::CRenderBufferPoolOpenGL(CRenderContext &context)
 
 IRenderBuffer *CRenderBufferPoolOpenGL::CreateRenderBuffer(void *header /* = nullptr */)
 {
-  return new CRenderBufferOpenGL(m_context, m_format, m_targetFormat, m_width, m_height);
+  return new CRenderBufferOpenGL(m_context,
+                                 m_pixeltype,
+                                 m_internalformat,
+                                 m_pixelformat,
+                                 m_bpp,
+                                 m_width,
+                                 m_height);
+}
+
+bool CRenderBufferPoolOpenGL::ConfigureInternal()
+{
+  // Configure CRenderBufferPoolOpenGLES
+  switch (m_format)
+  {
+  case AV_PIX_FMT_0RGB32:
+  {
+    m_pixeltype = GL_UNSIGNED_BYTE;
+    m_internalformat = GL_RGBA;
+    m_pixelformat = GL_BGRA;
+    m_bpp = sizeof(uint32_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB555:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  case AV_PIX_FMT_RGB565:
+  {
+    m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
+    m_internalformat = GL_RGB;
+    m_pixelformat = GL_RGB;
+    m_bpp = sizeof(uint16_t);
+    return true;
+  }
+  default:
+    break;
+  }
+
+  return false;
 }
 
 // --- CRPRendererOpenGL -------------------------------------------------------

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -43,7 +43,13 @@ namespace RETRO
   class CRenderBufferOpenGL : public CRenderBufferOpenGLES
   {
   public:
-    CRenderBufferOpenGL(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGL(CRenderContext &context,
+                        GLuint pixeltype,
+                        GLuint internalformat,
+                        GLuint pixelformat,
+                        GLuint bpp,
+                        unsigned int width,
+                        unsigned int height);
     ~CRenderBufferOpenGL() override = default;
 
     // implementation of IRenderBuffer via CRenderBufferOpenGLES
@@ -56,8 +62,10 @@ namespace RETRO
     CRenderBufferPoolOpenGL(CRenderContext &context);
     ~CRenderBufferPoolOpenGL() override = default;
 
+  protected:
     // implementation of CBaseRenderBufferPool via CRenderBufferPoolOpenGLES
     IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
+    bool ConfigureInternal();
   };
 
   class CRPRendererOpenGL : public CRPRendererOpenGLES

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -47,7 +47,13 @@ namespace RETRO
   class CRenderBufferOpenGLES : public CRenderBufferSysMem
   {
   public:
-    CRenderBufferOpenGLES(CRenderContext &context, AVPixelFormat format, AVPixelFormat targetFormat, unsigned int width, unsigned int height);
+    CRenderBufferOpenGLES(CRenderContext &context,
+                          GLuint pixeltype,
+                          GLuint internalformat,
+                          GLuint pixelformat,
+                          GLuint bpp,
+                          unsigned int width,
+                          unsigned int height);
     ~CRenderBufferOpenGLES() override;
 
     // implementation of IRenderBuffer via CRenderBufferSysMem
@@ -58,15 +64,12 @@ namespace RETRO
   protected:
     // Construction parameters
     CRenderContext &m_context;
-    const AVPixelFormat m_format;
-    const AVPixelFormat m_targetFormat;
+    const GLuint m_pixeltype;
+    const GLuint m_internalformat;
+    const GLuint m_pixelformat;
+    const GLuint m_bpp;
     const unsigned int m_width;
     const unsigned int m_height;
-
-    GLuint m_pixeltype;
-    GLuint m_internalformat;
-    GLuint m_pixelformat;
-    GLuint m_bpp;
 
     const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo
     GLuint m_textureId = 0;
@@ -83,21 +86,22 @@ namespace RETRO
     CRenderBufferPoolOpenGLES(CRenderContext &context);
     ~CRenderBufferPoolOpenGLES() override = default;
 
-    // implementation of IRenderBufferPool via CRenderBufferPoolSysMem
+    // implementation of IRenderBufferPool via CBaseRenderBufferPool
     bool IsCompatible(const CRenderVideoSettings &renderSettings) const override;
 
-    // implementation of CBaseRenderBufferPool via CRenderBufferPoolSysMem
-    IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
-
-    // GLES interface
-    bool SetTargetFormat(AVPixelFormat targetFormat);
-
   protected:
+    // implementation of CBaseRenderBufferPool
+    IRenderBuffer *CreateRenderBuffer(void *header = nullptr) override;
+    bool ConfigureInternal() override;
+
     // Construction parameters
     CRenderContext &m_context;
 
-    // GLES parameters
-    AVPixelFormat m_targetFormat = AV_PIX_FMT_NONE; //! @todo Change type to GLenum
+    // Configuration parameters
+    GLuint m_pixeltype = 0;
+    GLuint m_internalformat = 0;
+    GLuint m_pixelformat = 0;
+    GLuint m_bpp = 0;
   };
 
   class CRPRendererOpenGLES : public CRPBaseRenderer
@@ -114,7 +118,6 @@ namespace RETRO
 
   protected:
     // implementation of CRPBaseRenderer
-    bool ConfigureInternal() override;
     void RenderInternal(bool clear, uint8_t alpha) override;
     void FlushInternal() override;
 
@@ -133,7 +136,6 @@ namespace RETRO
 
     void Render(uint8_t alpha);
 
-    AVPixelFormat m_targetFormat = AV_PIX_FMT_NONE;
     GLenum m_textureTarget = GL_TEXTURE_2D;
     float m_clearColour = 0.0f;
   };


### PR DESCRIPTION
Configuration in the constructors doesn't work, because there's no way to indicate failure. Instead, we use the configuration hooks provided by the base class. There, we can return false for invalid configurations to avoid failure modes happening in the constructors, and guarantee that only valid parameters are passed to render buffers.

For https://github.com/xbmc/xbmc/pull/13504