### PR TITLE
CDVDVideoCodecDRMPRIME: use avcodec_get_hw_config

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -171,23 +171,36 @@ void CDVDVideoCodecDRMPRIME::Register()
   CDVDFactoryCodec::RegisterHWVideoCodec("drm_prime", CDVDVideoCodecDRMPRIME::Create);
 }
 
-const AVCodec* CDVDVideoCodecDRMPRIME::FindDecoder(CDVDStreamInfo& hints)
+static const AVCodecHWConfig* FindHWConfig(const AVCodec* codec)
+{
+  const AVCodecHWConfig* config = nullptr;
+  for (int n = 0; (config = avcodec_get_hw_config(codec, n)); n++)
+  {
+    if (config->pix_fmt != AV_PIX_FMT_DRM_PRIME)
+      continue;
+
+    if ((config->methods & AV_CODEC_HW_CONFIG_METHOD_INTERNAL))
+      return config;
+  }
+
+  return nullptr;
+}
+
+static const AVCodec* FindDecoder(CDVDStreamInfo& hints)
 {
   const AVCodec* codec = nullptr;
   void *i = 0;
 
   while ((codec = av_codec_iterate(&i)))
   {
-    if (av_codec_is_decoder(codec) && codec->id == hints.codec && codec->pix_fmts)
-    {
-      const AVPixelFormat* fmt = codec->pix_fmts;
-      while (*fmt != AV_PIX_FMT_NONE)
-      {
-        if (*fmt == AV_PIX_FMT_DRM_PRIME)
-          return codec;
-        fmt++;
-      }
-    }
+    if (!av_codec_is_decoder(codec))
+      continue;
+    if (codec->id != hints.codec)
+      continue;
+
+    const AVCodecHWConfig* config = FindHWConfig(codec);
+    if (config)
+      return codec;
   }
 
   return nullptr;
@@ -208,6 +221,7 @@ bool CDVDVideoCodecDRMPRIME::Open(CDVDStreamInfo& hints, CDVDCodecOptions& optio
   if (!m_pCodecContext)
     return false;
 
+  m_pCodecContext->pix_fmt = AV_PIX_FMT_DRM_PRIME;
   m_pCodecContext->codec_tag = hints.codec_tag;
   m_pCodecContext->coded_width = hints.width;
   m_pCodecContext->coded_height = hints.height;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -71,7 +71,6 @@ public:
   void SetCodecControl(int flags) override { m_codecControlFlags = flags; };
 
 protected:
-  const AVCodec* FindDecoder(CDVDStreamInfo& hints);
   void Drain();
   void SetPictureParams(VideoPicture* pVideoPicture);
 


### PR DESCRIPTION
This changes to use `avcodec_get_hw_config` to check for `AV_PIX_FMT_DRM_PRIME` support instead of checking `pix_fmts` array.

I am also including a work-in-progress commit that adds support for hwdevice codecs (possibly only my experimental rkvpu ffmpeg hwaccel that will use this).
Any idea on how I can get drm device path from gbm windowing in a non-hack way?

Feel free to fixup/squash/change as you see fit, hwdevice support can be dropped.