### PR TITLE
Update GL/GLES support

### DIFF
--- a/xbmc/cores/RetroPlayer/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/CMakeLists.txt
@@ -1,14 +1,12 @@
 set(SOURCES RetroPlayer.cpp
             RetroPlayerAutoSave.cpp
             RetroPlayerInput.cpp
-            RetroPlayerRendering.cpp
             RetroPlayerUtils.cpp
 )
 
 set(HEADERS RetroPlayer.h
             RetroPlayerAutoSave.h
             RetroPlayerInput.h
-            RetroPlayerRendering.h
             RetroPlayerTypes.h
             RetroPlayerUtils.h
 )

--- a/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerTypes.h
@@ -29,10 +29,7 @@ namespace RETRO
   class IRenderBufferPool;
   using RenderBufferPoolPtr = std::shared_ptr<IRenderBufferPool>;
   using RenderBufferPoolVector = std::vector<RenderBufferPoolPtr>;
-}
 
-namespace GAME
-{
-  typedef void (*RetroGLProcAddress)(void);
+  using HwProcedureAddress = void (*)();
 }
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferFBO.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferFBO.cpp
@@ -31,7 +31,7 @@ CRenderBufferFBO::CRenderBufferFBO(CRenderContext &context) :
 {
 }
 
-bool CRenderBufferFBO::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size)
+bool CRenderBufferFBO::Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size)
 {
   // Initialize IRenderBuffer
   m_format = format;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferFBO.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferFBO.h
@@ -46,7 +46,7 @@ namespace RETRO
     bool UploadTexture() override;
 
     // implementation of IRenderBuffer
-    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, unsigned int size) override;
+    bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height, size_t size) override;
     size_t GetFrameSize() const override { return 0; }
     uint8_t *GetMemory() override { return nullptr; }
 

--- a/xbmc/cores/RetroPlayer/process/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/process/CMakeLists.txt
@@ -4,4 +4,9 @@ set(SOURCES RPProcessInfo.cpp
 set(HEADERS RPProcessInfo.h
 )
 
+if(EGL_FOUND)
+  list(APPEND SOURCES egl/RPProcessInfoEGL.cpp)
+  list(APPEND HEADERS egl/RPProcessInfoEGL.h)
+endif()
+
 core_add_library(rp-process)

--- a/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
+++ b/xbmc/cores/RetroPlayer/process/RPProcessInfo.h
@@ -77,6 +77,17 @@ namespace RETRO
     bool HasScalingMethod(ESCALINGMETHOD scalingMethod) const;
     ESCALINGMETHOD GetDefaultScalingMethod() const { return m_defaultScalingMethod; }
 
+    /*!
+     * \brief Get a symbol from the hardware context
+     *
+     * \param symbol The symbol's name
+     *
+     * \return A function pointer for the specified symbol, or nullptr if
+     *         unavailable
+     */
+    virtual HwProcedureAddress GetHwProcedureAddress(const char* symbol) { return nullptr; }
+    ///}
+
     // player video
     void SetVideoPixelFormat(AVPixelFormat pixFormat);
     void SetVideoDimensions(int width, int height);

--- a/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
+++ b/xbmc/cores/RetroPlayer/process/X11/RPProcessInfoX11.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoX11::CRPProcessInfoX11() :
-  CRPProcessInfo("X11")
+  CRPProcessInfoEGL("X11")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoAmlogic::CRPProcessInfoAmlogic() :
-  CRPProcessInfo("Amlogic")
+  CRPProcessInfoEGL("Amlogic")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
+++ b/xbmc/cores/RetroPlayer/process/amlogic/RPProcessInfoAmlogic.h
@@ -19,13 +19,13 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoAmlogic : public CRPProcessInfo
+  class CRPProcessInfoAmlogic : public CRPProcessInfoEGL
   {
   public:
     CRPProcessInfoAmlogic();

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoAndroid::CRPProcessInfoAndroid() :
-  CRPProcessInfo("Android")
+  CRPProcessInfoEGL("Android")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
+++ b/xbmc/cores/RetroPlayer/process/android/RPProcessInfoAndroid.h
@@ -19,13 +19,13 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoAndroid : public CRPProcessInfo
+  class CRPProcessInfoAndroid : public CRPProcessInfoEGL
   {
   public:
     CRPProcessInfoAndroid();

--- a/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.cpp
+++ b/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.cpp
@@ -17,21 +17,20 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
-#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
+#include "RPProcessInfoEGL.h"
 
-namespace KODI
+#include <EGL/egl.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+CRPProcessInfoEGL::CRPProcessInfoEGL(std::string platformName) :
+  CRPProcessInfo(std::move(platformName))
 {
-namespace RETRO
-{
-  class CRPProcessInfoX11 : public CRPProcessInfoEGL
-  {
-  public:
-    CRPProcessInfoX11();
-
-    static CRPProcessInfo* Create();
-    static void Register();
-  };
 }
+
+HwProcedureAddress CRPProcessInfoEGL::GetHwProcedureAddress(const char* symbol)
+{
+  return static_cast<HwProcedureAddress>(eglGetProcAddress(symbol));
 }

--- a/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
+++ b/xbmc/cores/RetroPlayer/process/egl/RPProcessInfoEGL.h
@@ -19,19 +19,19 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoX11 : public CRPProcessInfoEGL
+  class CRPProcessInfoEGL : public CRPProcessInfo
   {
   public:
-    CRPProcessInfoX11();
+    CRPProcessInfoEGL(std::string platformName);
 
-    static CRPProcessInfo* Create();
-    static void Register();
+    // Implementation of CRPProcessInfo
+    HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;
   };
 }
 }

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoGbm::CRPProcessInfoGbm() :
-  CRPProcessInfo("GBM")
+  CRPProcessInfoEGL("GBM")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
+++ b/xbmc/cores/RetroPlayer/process/gbm/RPProcessInfoGbm.h
@@ -19,13 +19,13 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoGbm : public CRPProcessInfo
+  class CRPProcessInfoGbm : public CRPProcessInfoEGL
   {
   public:
     CRPProcessInfoGbm();

--- a/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.cpp
+++ b/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoPi::CRPProcessInfoPi() :
-  CRPProcessInfo("RPi")
+  CRPProcessInfoEGL("RPi")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h
+++ b/xbmc/cores/RetroPlayer/process/rbpi/RPProcessInfoPi.h
@@ -19,13 +19,13 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoPi : public CRPProcessInfo
+  class CRPProcessInfoPi : public CRPProcessInfoEGL
   {
   public:
     CRPProcessInfoPi();

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.cpp
@@ -24,7 +24,7 @@ using namespace KODI;
 using namespace RETRO;
 
 CRPProcessInfoWayland::CRPProcessInfoWayland() :
-  CRPProcessInfo("Wayland")
+  CRPProcessInfoEGL("Wayland")
 {
 }
 

--- a/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
+++ b/xbmc/cores/RetroPlayer/process/wayland/RPProcessInfoWayland.h
@@ -19,13 +19,13 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/process/RPProcessInfo.h"
+#include "cores/RetroPlayer/process/egl/RPProcessInfoEGL.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-  class CRPProcessInfoWayland : public CRPProcessInfo
+  class CRPProcessInfoWayland : public CRPProcessInfoEGL
   {
   public:
     CRPProcessInfoWayland();

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -207,7 +207,7 @@ bool CRPRenderManager::Create()
   if (!renderer)
     return false;
 
-  renderer->Configure(m_format, m_width, m_height, m_orientation);
+  renderer->Configure(m_format, m_width, m_height);
 
   std::vector<IRenderBuffer*> renderBuffers;
   for (IRenderBufferPool *bufferPool : m_processInfo.GetBufferManager().GetBufferPools())

--- a/xbmc/cores/RetroPlayer/streams/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/streams/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES RetroPlayerAudio.cpp
+            RetroPlayerRendering.cpp
             RetroPlayerStreamTypes.cpp
             RetroPlayerVideo.cpp
             RPStreamManager.cpp
@@ -7,6 +8,7 @@ set(SOURCES RetroPlayerAudio.cpp
 set(HEADERS IRetroPlayerStream.h
             IStreamManager.h
             RetroPlayerAudio.h
+            RetroPlayerRendering.h
             RetroPlayerStreamTypes.h
             RetroPlayerVideo.h
             RPStreamManager.h

--- a/xbmc/cores/RetroPlayer/streams/IStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/IStreamManager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "RetroPlayerStreamTypes.h"
+#include "cores/RetroPlayer/RetroPlayerTypes.h"
 
 namespace KODI
 {
@@ -46,6 +47,15 @@ public:
    * \param stream The stream to close
    */
   virtual void CloseStream(StreamPtr stream) = 0;
+
+  /*!
+   * \brief Get a symbol from the hardware context
+   *
+   * \param symbol The symbol's name
+   *
+   * \return A function pointer for the specified symbol
+   */
+  virtual HwProcedureAddress GetHwProcedureAddress(const char* symbol) = 0;
 };
 
 }

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -21,9 +21,10 @@
 #include "RPStreamManager.h"
 #include "IRetroPlayerStream.h"
 #include "RetroPlayerAudio.h"
-//#include "RetroPlayerHardwareBuffer.h" //! @todo
+#include "RetroPlayerRendering.h"
 //#include "RetroPlayerSoftwareBuffer.h" //! @todo
 #include "RetroPlayerVideo.h"
+#include "cores/RetroPlayer/process/RPProcessInfo.h"
 
 using namespace KODI;
 using namespace RETRO;
@@ -61,7 +62,7 @@ StreamPtr CRPStreamManager::CreateStream(StreamType streamType)
   }
   case StreamType::HW_BUFFER:
   {
-    //return StreamPtr(new CRetroPlayerHardware(m_renderManager, m_processInfo)); //! @todo
+    return StreamPtr(new CRetroPlayerRendering(m_renderManager, m_processInfo));
   }
   default:
     break;
@@ -79,4 +80,9 @@ void CRPStreamManager::CloseStream(StreamPtr stream)
 
     stream->CloseStream();
   }
+}
+
+HwProcedureAddress CRPStreamManager::GetHwProcedureAddress(const char* symbol)
+{
+  return m_processInfo.GetHwProcedureAddress(symbol);
 }

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
@@ -40,8 +40,7 @@ namespace RETRO
     // Implementation of IStreamManager
     StreamPtr CreateStream(StreamType streamType) override;
     void CloseStream(StreamPtr stream) override;
-
-    GAME::IGameRenderingCallback* HardwareRendering();
+    HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;
 
   private:
     // Construction parameters

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.cpp
@@ -22,44 +22,43 @@
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/RPRenderManager.h"
 
-#include "windowing/X11/WinSystemX11GLContext.h"
-#include "rendering/RenderSystem.h"
-#include "ServiceBroker.h"
-#include "utils/log.h"
-
 using namespace KODI;
 using namespace RETRO;
 
 CRetroPlayerRendering::CRetroPlayerRendering(CRPRenderManager& renderManager, CRPProcessInfo& processInfo) :
   m_renderManager(renderManager),
   m_processInfo(processInfo),
-  m_width(640),
-  m_height(480)
+  m_width(640), //! @todo
+  m_height(480) //! @todo
 {
 }
 
-bool CRetroPlayerRendering::Create()
+bool CRetroPlayerRendering::OpenStream(const StreamProperties& properties)
 {
   m_processInfo.SetVideoPixelFormat(AV_PIX_FMT_BGRA);
   m_processInfo.SetVideoDimensions(m_width, m_height);
 
-  if (!m_renderManager.Configure(AV_PIX_FMT_BGRA, m_width, m_height, 0))
+  if (!m_renderManager.Configure(AV_PIX_FMT_BGRA, m_width, m_height, m_width, m_height))
     return false;
 
   return m_renderManager.Create();
 }
 
-void CRetroPlayerRendering::Destroy()
+void CRetroPlayerRendering::CloseStream()
 {
   //! @todo
 }
 
-void CRetroPlayerRendering::RenderFrame()
+bool CRetroPlayerRendering::GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer)
 {
-  m_renderManager.RenderFrame();
+  HwFramebufferBuffer& hwBuffer = reinterpret_cast<HwFramebufferBuffer&>(buffer);
+
+  hwBuffer.framebuffer = m_renderManager.GetCurrentFramebuffer();
+
+  return true;
 }
 
-uintptr_t CRetroPlayerRendering::GetCurrentFramebuffer()
+void CRetroPlayerRendering::AddStreamData(const StreamPacket &packet)
 {
-  return m_renderManager.GetCurrentFramebuffer();
+  m_renderManager.RenderFrame();
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerRendering.h
@@ -19,11 +19,10 @@
  */
 #pragma once
 
-#include "games/addons/GameClientCallbacks.h"
+#include "IRetroPlayerStream.h"
+#include "RetroPlayerStreamTypes.h"
 
-#include "system_gl.h"
-
-#include <EGL/egl.h>
+#include <stdint.h>
 
 namespace KODI
 {
@@ -32,24 +31,35 @@ namespace RETRO
   class CRPProcessInfo;
   class CRPRenderManager;
 
-  class CRetroPlayerRendering : public GAME::IGameRenderingCallback
+  struct HwFramebufferBuffer
+  {
+    uintptr_t framebuffer;
+  };
+
+  struct HwFramebufferPacket
+  {
+    uintptr_t framebuffer;
+  };
+
+  class CRetroPlayerRendering : public IRetroPlayerStream
   {
   public:
     CRetroPlayerRendering(CRPRenderManager& m_renderManager, CRPProcessInfo& m_processInfo);
 
     ~CRetroPlayerRendering() override = default;
 
-    // implementation of IGameRenderingCallback
-    bool Create() override;
-    void Destroy() override;
-    uintptr_t GetCurrentFramebuffer() override;
-    GAME::RetroGLProcAddress GetProcAddress(const char *sym) override { return eglGetProcAddress(sym); }
-    void RenderFrame() override;
+    // implementation of IRetroPlayerStream
+    bool OpenStream(const StreamProperties& properties) override;
+    bool GetStreamBuffer(unsigned int width, unsigned int height, StreamBuffer& buffer) override;
+    void AddStreamData(const StreamPacket &packet) override;
+    void CloseStream() override;
 
   private:
     // Construction parameters
     CRPRenderManager& m_renderManager;
-    CRPProcessInfo&   m_processInfo;
+    CRPProcessInfo& m_processInfo;
+
+    // Rendering properties
     unsigned int m_width;
     unsigned int m_height;
   };

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.cpp
@@ -18,7 +18,6 @@
  *
  */
 
-#include "RetroPlayerRendering.h"
 #include "RetroPlayerVideo.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "cores/RetroPlayer/rendering/RenderTranslator.h"
@@ -117,12 +116,4 @@ void CRetroPlayerVideo::CloseStream()
     m_renderManager.Flush();
     m_bOpen = false;
   }
-}
-
-GAME::IGameRenderingCallback* CRetroPlayerVideo::HardwareRendering()
-{
-  if (!m_hardwareRendering)
-    m_hardwareRendering.reset(new CRetroPlayerRendering(m_renderManager, m_processInfo));
-
-  return m_hardwareRendering.get();
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerVideo.h
@@ -20,13 +20,10 @@
 #pragma once
 
 #include "IRetroPlayerStream.h"
-#include "games/addons/GameClientCallbacks.h" //! @todo
 
 extern "C" {
 #include "libavutil/pixfmt.h"
 }
-
-#include <memory> //! @todo
 
 namespace KODI
 {
@@ -78,9 +75,6 @@ namespace RETRO
 
     // Stream properties
     bool m_bOpen = false;
-
-    // Hardware rendering properties
-    std::shared_ptr<GAME::IGameRenderingCallback> m_hardwareRendering; //! @todo
   };
 }
 }

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -576,39 +576,11 @@ void CGameClient::LogException(const char* strFunctionName) const
   CLog::Log(LOGERROR, "Please contact the developer of this add-on: %s", Author().c_str());
 }
 
-
-void CGameClient::EnableHardwareRendering(const game_hw_info *hw_info)
-{
-  CLog::Log(LOGINFO, "GAME - entered EnableHardwareRendering");
-  //m_video->HardwareRendering()->SetHwInfo(hw_info);
-}
-
-uintptr_t CGameClient::HwGetCurrentFramebuffer()
-{
-  return m_video->HardwareRendering()->GetCurrentFramebuffer();
-}
-
-game_proc_address_t CGameClient::HwGetProcAddress(const char *sym)
-{
-  return m_video->HardwareRendering()->GetProcAddress(sym);
-}
-
-void CGameClient::HwContextReset()
+void CGameClient::HardwareContextReset()
 {
   try { LogError(m_struct.toAddon.HwContextReset(), "HwContextReset()"); }
   catch (...) { LogException("HwContextReset()"); }
 }
-
-void CGameClient::CreateHwRenderContext()
-{
-  m_video->HardwareRendering()->Create();
-}
-
-void CGameClient::RenderFrame()
-{
-  m_video->HardwareRendering()->RenderFrame();
-}
-
 
 void CGameClient::cb_close_game(void* kodiInstance)
 {
@@ -684,7 +656,7 @@ game_proc_address_t CGameClient::cb_hw_get_proc_address(void* kodiInstance, cons
   if (!gameClient)
     return nullptr;
 
-  return gameClient->HwGetProcAddress(sym);
+  return gameClient->Streams().GetHwProcedureAddress(sym);
 }
 
 bool CGameClient::cb_input_event(void* kodiInstance, const game_input_event* event)

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -22,6 +22,7 @@
 #include "GameClientSubsystem.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "games/addons/streams/GameClientStreamHwFramebuffer.h"
 #include "games/GameTypes.h"
 #include "threads/CriticalSection.h"
 
@@ -53,7 +54,8 @@ class IGameInputCallback;
  * \ingroup games
  * \brief Interface between Kodi and Game add-ons.
  */
-class CGameClient : public ADDON::CAddonDll
+class CGameClient : public ADDON::CAddonDll,
+                    public IHwFramebufferCallback
 {
 public:
   static std::unique_ptr<CGameClient> FromExtension(ADDON::CAddonInfo addonInfo, const cp_extension_t* ext);
@@ -105,13 +107,8 @@ public:
   bool Serialize(uint8_t* data, size_t size);
   bool Deserialize(const uint8_t* data, size_t size);
 
-  // OpenGL HW Rendering
-  void EnableHardwareRendering(const game_hw_info *hw_info);
-  uintptr_t HwGetCurrentFramebuffer();
-  game_proc_address_t HwGetProcAddress(const char *sym);
-  void RenderFrame();
-  void HwContextReset();
-  void CreateHwRenderContext();
+  // Implementation of IHwFramebufferCallback
+  void HardwareContextReset() override;
 
   /*!
     * @brief To get the interface table used between addon and kodi

--- a/xbmc/games/addons/GameClientCallbacks.h
+++ b/xbmc/games/addons/GameClientCallbacks.h
@@ -19,26 +19,10 @@
  */
 #pragma once
 
-#include "cores/RetroPlayer/streams/RetroPlayerStreamTypes.h"
-
 namespace KODI
 {
 namespace GAME
 {
-  class IGameRenderingCallback;
-
-  class IGameRenderingCallback
-  {
-  public:
-    virtual ~IGameRenderingCallback() = default;
-
-    virtual bool Create() = 0;
-    virtual void Destroy() = 0;
-    virtual uintptr_t GetCurrentFramebuffer() = 0;
-    virtual RETRO::ProcedureAddress GetProcAddress(const char *sym) = 0;
-    virtual void RenderFrame() = 0;
-  };
-
   class IGameInputCallback
   {
   public:

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.cpp
@@ -42,7 +42,7 @@ using namespace GAME;
 
 CGameClientReversiblePlayback::CGameClientReversiblePlayback(CGameClient* gameClient, double fps, size_t serializeSize) :
   m_gameClient(gameClient),
-  m_gameLoop(this, this, fps),
+  m_gameLoop(this, fps),
   m_savestateWriter(new CSavestateWriter),
   m_savestateReader(new CSavestateReader),
   m_totalFrameCount(0),
@@ -283,16 +283,6 @@ void CGameClientReversiblePlayback::UpdatePlaybackStats()
   m_playTimeMs = MathUtils::round_int(1000.0 * played / m_gameLoop.FPS());
   m_totalTimeMs = MathUtils::round_int(1000.0 * total / m_gameLoop.FPS());
   m_cacheTimeMs = MathUtils::round_int(1000.0 * cached / m_gameLoop.FPS());
-}
-
-void CGameClientReversiblePlayback::HwContextReset()
-{
-  m_gameClient->HwContextReset();
-}
-
-void CGameClientReversiblePlayback::CreateHwRenderContext()
-{
-  m_gameClient->CreateHwRenderContext();
 }
 
 void CGameClientReversiblePlayback::Notify(const Observable &obs, const ObservableMessage msg)

--- a/xbmc/games/addons/playback/GameClientReversiblePlayback.h
+++ b/xbmc/games/addons/playback/GameClientReversiblePlayback.h
@@ -39,7 +39,6 @@ namespace GAME
 
   class CGameClientReversiblePlayback : public IGameClientPlayback,
                                         public IGameLoopCallback,
-                                        public IHardwareRendering,
                                         public Observer
   {
   public:
@@ -63,10 +62,6 @@ namespace GAME
     // implementation of IGameLoopCallback
     virtual void FrameEvent() override;
     virtual void RewindEvent() override;
-
-    // implementation of IHardwareRendering
-    virtual void HwContextReset() override;
-    virtual void CreateHwRenderContext() override;
 
     // implementation of Observer
     virtual void Notify(const Observable &obs, const ObservableMessage msg) override;

--- a/xbmc/games/addons/playback/GameLoop.cpp
+++ b/xbmc/games/addons/playback/GameLoop.cpp
@@ -30,10 +30,9 @@ using namespace GAME;
 #define DEFAULT_FPS  60  // In case fps is 0 (shouldn't happen)
 #define FOREVER_MS   (7 * 24 * 60 * 60 * 1000) // 1 week is large enough
 
-CGameLoop::CGameLoop(IGameLoopCallback* callback, IHardwareRendering* hwRenderCallback, double fps) :
+CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps) :
   CThread("GameLoop"),
   m_callback(callback),
-  m_hwRenderCallback(hwRenderCallback),
   m_fps(fps ? fps : DEFAULT_FPS),
   m_speedFactor(0.0),
   m_lastFrameMs(0.0)
@@ -83,12 +82,6 @@ void CGameLoop::Process(void)
   double nextFrameMs = NowMs();
 
   CSingleLock lock(m_mutex);
-
-  if (m_hwRenderCallback)
-  {
-    m_hwRenderCallback->CreateHwRenderContext();
-    m_hwRenderCallback->HwContextReset();
-  }
 
   while (!m_bStop)
   {

--- a/xbmc/games/addons/playback/GameLoop.h
+++ b/xbmc/games/addons/playback/GameLoop.h
@@ -43,19 +43,10 @@ namespace GAME
     virtual void RewindEvent() = 0;
   };
 
-  class IHardwareRendering
-  {
-  public:
-    virtual ~IHardwareRendering() = default;
-
-    virtual void HwContextReset() = 0;
-    virtual void CreateHwRenderContext() = 0;
-  };
-
   class CGameLoop : protected CThread
   {
   public:
-    CGameLoop(IGameLoopCallback* callback, IHardwareRendering* hwRenderCallback, double fps);
+    CGameLoop(IGameLoopCallback* callback, double fps);
 
     virtual ~CGameLoop();
 
@@ -78,7 +69,6 @@ namespace GAME
     double NowMs() const;
 
     IGameLoopCallback* const m_callback;
-    IHardwareRendering* const m_hwRenderCallback;
     const double             m_fps;
     double                   m_speedFactor;
     bool                     m_bPauseAsync = false;

--- a/xbmc/games/addons/streams/CMakeLists.txt
+++ b/xbmc/games/addons/streams/CMakeLists.txt
@@ -1,9 +1,11 @@
 set(SOURCES GameClientStreamAudio.cpp
+            GameClientStreamHwFramebuffer.cpp
             GameClientStreams.cpp
             GameClientStreamVideo.cpp
 )
 
 set(HEADERS GameClientStreamAudio.h
+            GameClientStreamHwFramebuffer.h
             GameClientStreams.h
             GameClientStreamVideo.h
             IGameClientStream.h

--- a/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.cpp
@@ -1,0 +1,93 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientStreamHwFramebuffer.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "cores/RetroPlayer/streams/RetroPlayerRendering.h"
+#include "utils/log.h"
+
+using namespace KODI;
+using namespace GAME;
+
+CGameClientStreamHwFramebuffer::CGameClientStreamHwFramebuffer(IHwFramebufferCallback& callback) :
+  m_callback(callback)
+{
+}
+
+bool CGameClientStreamHwFramebuffer::OpenStream(RETRO::IRetroPlayerStream* stream, const game_stream_properties& properties)
+{
+  RETRO::CRetroPlayerRendering* renderingStream = dynamic_cast<RETRO::CRetroPlayerRendering*>(stream);
+  if (renderingStream == nullptr)
+  {
+    CLog::Log(LOGERROR, "GAME: RetroPlayer stream is not an audio stream");
+    return false;
+  }
+
+  RETRO::StreamProperties renderingProperties{};
+
+  if (stream->OpenStream(renderingProperties))
+  {
+    m_stream = stream;
+    m_callback.HardwareContextReset();
+  }
+
+  return m_stream != nullptr;
+}
+
+void CGameClientStreamHwFramebuffer::CloseStream()
+{
+  m_stream->CloseStream();
+  m_stream = nullptr;
+}
+
+bool CGameClientStreamHwFramebuffer::GetBuffer(unsigned int width, unsigned int height, game_stream_buffer& buffer)
+{
+  if (buffer.type != GAME_STREAM_HW_FRAMEBUFFER)
+    return false;
+
+  if (m_stream != nullptr)
+  {
+    RETRO::HwFramebufferBuffer hwFramebufferBuffer;
+    if (m_stream->GetStreamBuffer(0, 0, reinterpret_cast<RETRO::StreamBuffer&>(hwFramebufferBuffer)))
+    {
+      buffer.hw_framebuffer.framebuffer = hwFramebufferBuffer.framebuffer;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void CGameClientStreamHwFramebuffer::AddData(const game_stream_packet &packet)
+{
+  if (packet.type != GAME_STREAM_HW_FRAMEBUFFER)
+    return;
+
+  if (m_stream != nullptr)
+  {
+    const game_stream_hw_framebuffer_packet &hwFramebuffer = packet.hw_framebuffer;
+
+    RETRO::HwFramebufferPacket hwFramebufferPacket{
+      hwFramebuffer.framebuffer
+    };
+
+    m_stream->AddStreamData(reinterpret_cast<const RETRO::StreamPacket&>(hwFramebufferPacket));
+  }
+}

--- a/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.h
+++ b/xbmc/games/addons/streams/GameClientStreamHwFramebuffer.h
@@ -1,0 +1,68 @@
+/*
+ *      Copyright (C) 2018 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "IGameClientStream.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+  class IRetroPlayerStream;
+}
+
+namespace GAME
+{
+
+class IHwFramebufferCallback
+{
+public:
+  virtual ~IHwFramebufferCallback() = default;
+
+  /*!
+   * \brief Invalidates the current HW context and reinitializes GPU resources
+   *
+   * Any GL state is lost, and must not be deinitialized explicitly.
+   */
+  virtual void HardwareContextReset() = 0;
+};
+
+class CGameClientStreamHwFramebuffer : public IGameClientStream
+{
+public:
+  CGameClientStreamHwFramebuffer(IHwFramebufferCallback& callback);
+  ~CGameClientStreamHwFramebuffer() override = default;
+
+  // Implementation of IGameClientStream
+  bool OpenStream(RETRO::IRetroPlayerStream* stream, const game_stream_properties& properties) override;
+  void CloseStream() override;
+  bool GetBuffer(unsigned int width, unsigned int height, game_stream_buffer& buffer);
+  void AddData(const game_stream_packet& packet) override;
+
+private:
+  // Construction parameters
+  IHwFramebufferCallback& m_callback;
+
+  // Stream parameters
+  RETRO::IRetroPlayerStream* m_stream;
+};
+
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/streams/GameClientStreams.cpp
+++ b/xbmc/games/addons/streams/GameClientStreams.cpp
@@ -20,6 +20,7 @@
 
 #include "GameClientStreams.h"
 #include "GameClientStreamAudio.h"
+#include "GameClientStreamHwFramebuffer.h"
 #include "GameClientStreamVideo.h"
 #include "cores/RetroPlayer/streams/IRetroPlayerStream.h"
 #include "cores/RetroPlayer/streams/IStreamManager.h"
@@ -95,6 +96,14 @@ void CGameClientStreams::CloseStream(IGameClientStream *stream)
   }
 }
 
+game_proc_address_t CGameClientStreams::GetHwProcedureAddress(const char *symbol)
+{
+  if (m_streamManager != nullptr)
+    return m_streamManager->GetHwProcedureAddress(symbol);
+
+  return nullptr;
+}
+
 std::unique_ptr<IGameClientStream> CGameClientStreams::CreateStream(GAME_STREAM_TYPE streamType) const
 {
   std::unique_ptr<IGameClientStream> gameStream;
@@ -109,6 +118,11 @@ std::unique_ptr<IGameClientStream> CGameClientStreams::CreateStream(GAME_STREAM_
   case GAME_STREAM_VIDEO:
   {
     gameStream.reset(new CGameClientStreamVideo);
+    break;
+  }
+  case GAME_STREAM_HW_FRAMEBUFFER:
+  {
+    gameStream.reset(new CGameClientStreamHwFramebuffer(m_gameClient));
     break;
   }
   default:

--- a/xbmc/games/addons/streams/GameClientStreams.h
+++ b/xbmc/games/addons/streams/GameClientStreams.h
@@ -48,6 +48,8 @@ public:
   IGameClientStream* OpenStream(const game_stream_properties &properties);
   void CloseStream(IGameClientStream* stream);
 
+  game_proc_address_t GetHwProcedureAddress(const char *sym);
+
 private:
   // Utility functions
   std::unique_ptr<IGameClientStream> CreateStream(GAME_STREAM_TYPE streamType) const;


### PR DESCRIPTION
This adapts the GL/GLES work to the stream abstraction added to RetroPlayer in https://github.com/xbmc/xbmc/pull/13976.

This is what the resulting patch looks like after squashing the update to your branch: https://github.com/garbear/xbmc/commit/retro-gl-gbm-squashed