### PR TITLE
Integer Scaling support implementation to improve the viewing quality of Pixel Art games

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21955,3 +21955,15 @@ msgstr ""
 msgctxt "#39118"
 msgid "Share debug log"
 msgstr ""
+
+#. Label for enabling scaling filter for better Pixel Art Games
+#:xbmc/settings/settings.xml
+msgctxt "#39119"
+msgid "Enable Integer Scaling Filter (NN)"
+msgstr ""
+
+#. Description of setting with label #39119 "Enable Integer Scaling Filter (NN)"
+#: system/settings/settings.xml
+msgctxt "#39120"
+msgid "Integer scaling (IS) is a nearest-neighbor upscaling technique that simply scales up the existing pixels by an integer (i.e., whole number) multiplier.Nearest-neighbor (NN) interpolation works by filling in the missing color values in the upscaled image with that of the coordinate-mapped nearest source pixel value"
+msgstr ""

--- a/system/settings/gbm.xml
+++ b/system/settings/gbm.xml
@@ -36,6 +36,11 @@
         <setting id="videoscreen.screen">
           <visible>false</visible>
         </setting>
+        <setting id="videoscreen.scalingfilter" type="boolean" label="39119" help="39120">
+          <level>3</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">
           <level>3</level>
           <default>false</default>

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -253,6 +253,7 @@ std::string CSkinInfo::GetSkinPath(const std::string& strFile, RESOLUTION_INFO *
   const RESOLUTION_INFO &target = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
   *res = *std::min_element(m_resolutions.begin(), m_resolutions.end(), closestRes(target));
 
+  *res=target;
   std::string strPath = URIUtils::AddFileToFolder(strPathToUse, res->strMode, strFile);
   if (CFile::Exists(strPath))
     return strPath;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -676,7 +676,7 @@ void CGUIDialogKeyboardGeneric::ShowWordList(int direct)
 {
   CSingleLock lock(m_CS);
   std::wstring hzlist = L"";
-  CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, true);
+  CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(m_coordsRes, false);
   float width = m_listfont->GetCharWidth(L'<') + m_listfont->GetCharWidth(L'>');
   float spacewidth = m_listfont->GetCharWidth(L' ');
   float numwidth = m_listfont->GetCharWidth(L'1') + m_listfont->GetCharWidth(L'.');

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -94,8 +94,11 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName, const std::str
   if (pFont)
     return pFont;
 
-  if (!sourceRes) // no source res specified, so assume the skin res
-    sourceRes = &m_skinResolution;
+  const RESOLUTION_INFO  srcRes = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+ if (&srcRes) // no source res specified, try gfxContext Res
+	 sourceRes = &srcRes;
+ else  // no source res specified, so assume the skin res
+	sourceRes = &m_skinResolution;
 
   float newSize = (float)iSize;
   RescaleFontSizeAndAspect(&newSize, &aspect, *sourceRes, preserveAspect);

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -43,7 +43,7 @@ CGUIWindow::CGUIWindow(int id, const std::string &xmlFile)
   CGUIWindow::SetID(id);
   SetProperty("xmlfile", xmlFile);
   m_lastControlID = 0;
-  m_needsScaling = true;
+  m_needsScaling = false;
   m_windowLoaded = false;
   m_loadType = LOAD_EVERY_TIME;
   m_closing = false;

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -71,7 +71,7 @@ void CRenderSystemBase::ShowSplash(const std::string& message)
   CServiceBroker::GetWinSystem()->GetGfxContext().Clear();
 
   RESOLUTION_INFO res = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-  CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(res, true);
+  CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(res, false);
 
   //render splash image
   BeginRender();

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -418,6 +418,7 @@ const std::string CSettings::SETTING_SOURCE_VIDEOS = "source.videos";
 const std::string CSettings::SETTING_SOURCE_MUSIC = "source.music";
 const std::string CSettings::SETTING_SOURCE_PICTURES = "source.pictures";
 
+const std::string CSettings::SETTING_VIDEOSCREEN_SCALING_FILTER="videoscreen.scalingfilter";
 bool CSettings::Initialize()
 {
   CSingleLock lock(m_critical);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -386,6 +386,7 @@ public:
   static const int VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES = 1;
   static const int VIDEOLIBRARY_THUMB_SHOW_UNWATCHED_EPISODE = 2;
 
+  static const std::string SETTING_VIDEOSCREEN_SCALING_FILTER;
   /*!
    \brief Creates a new settings wrapper around a new settings manager.
 

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -403,7 +403,7 @@ void CGUIWindowSettingsScreenCalibration::DoProcess(unsigned int currentTime, CD
   for (int i = CONTROL_TOP_LEFT; i <= CONTROL_PIXEL_RATIO; i++)
     SET_CONTROL_HIDDEN(i);
 
-  m_needsScaling = true;
+  m_needsScaling = false;
   CGUIWindow::DoProcess(currentTime, dirtyregions);
   m_needsScaling = false;
 
@@ -424,7 +424,7 @@ void CGUIWindowSettingsScreenCalibration::DoProcess(unsigned int currentTime, CD
 void CGUIWindowSettingsScreenCalibration::DoRender()
 {
   // we set that we need scaling here to render so that anything else on screen scales correctly
-  m_needsScaling = true;
+  m_needsScaling = false;
   CGUIWindow::DoRender();
   m_needsScaling = false;
 }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -209,6 +209,11 @@ REFRESHRATE CWinSystemBase::DefaultRefreshRate(std::vector<REFRESHRATE> rates)
   return bestmatch;
 }
 
+bool CWinSystemBase::UseScalingFilter()
+{
+  return false;
+}
+
 bool CWinSystemBase::UseLimitedColor()
 {
   return false;

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -67,6 +67,8 @@ public:
   virtual bool HasCursor(){ return true; }
   //some platforms have api for gesture inertial scrolling - default to false and use the InertialScrollingHandler
   virtual bool HasInertialGestures(){ return false; }
+  //Checking for whether user has toggled ScalingFilter or not!?
+  virtual bool UseScalingFilter();
   //does the output expect limited color range (ie 16-235)
   virtual bool UseLimitedColor();
   //the number of presentation buffers

--- a/xbmc/windowing/gbm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/DRMAtomic.cpp
@@ -90,8 +90,8 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       }
       else
       {
-	 AddProperty(object, "CRTC_W",m_mode->hdisplay);
-	 AddProperty(object, "CRTC_H", m_mode->vdisplay); 
+	 AddProperty(m_gui_plane, "CRTC_W",m_mode->hdisplay);
+	 AddProperty(m_gui_plane, "CRTC_H", m_mode->vdisplay); 
       }
     }
 

--- a/xbmc/windowing/gbm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/DRMAtomic.h
@@ -32,7 +32,8 @@ public:
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
   bool ResetPlanes();
-
+  uint32_t GetScalingFactor(uint32_t destWidth, uint32_t destHeight, uint32_t srcWidth, uint32_t srcHeight);
+  bool  SetScalingFilter(struct drm_object *object, const char *name);
   bool m_need_modeset;
   bool m_active = true;
   drmModeAtomicReq *m_req = nullptr;

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -233,6 +233,13 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer)
     m_videoLayerBridge.reset();
   }
 }
+/*Adding support for Selecting Integer Scaling filter for PiXel Art Games based
+ * on Setting: "Setting->System->Display->Integer_scaling_Filter"
+ */
+bool CWinSystemGbm::UseScalingFilter()
+{
+  return CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOSCREEN_SCALING_FILTER);
+}
 
 bool CWinSystemGbm::UseLimitedColor()
 {

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -46,6 +46,7 @@ public:
   bool CanDoWindowed() override { return false; }
   void UpdateResolutions() override;
 
+  bool UseScalingFilter() override; 
   bool UseLimitedColor() override;
 
   bool Hide() override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -68,6 +68,12 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
   {
     return false;
   }
+  res.Overscan.right = 640;
+  res.Overscan.bottom = 480;
+  res.iWidth = 640;
+  res.iHeight = 480;
+  res.iScreenWidth = 640;
+  res.iScreenHeight = 480;
 
   if (!m_DRM->SetMode(res))
   {
@@ -77,7 +83,6 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
 
   uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
   std::vector<uint64_t> *modifiers = m_DRM->GetGuiPlaneModifiersForFormat(format);
-
   if (!m_GBM->CreateSurface(res.iWidth, res.iHeight, format, modifiers->data(), modifiers->size()))
   {
     CLog::Log(LOGERROR, "CWinSystemGbmEGLContext::{} - failed to initialize GBM", __FUNCTION__);

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -138,7 +138,7 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
         windowName = window->GetProperty("xmlfile").asString();
       info += "Window: " + windowName + "\n";
       // transform the mouse coordinates to this window's coordinates
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(window->GetCoordsRes(), true);
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetScalingResolution(window->GetCoordsRes(),false);
       point.x *= CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleX();
       point.y *= CServiceBroker::GetWinSystem()->GetGfxContext().GetGUIScaleY();
       CServiceBroker::GetWinSystem()->GetGfxContext().SetRenderingResolution(CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(), false);


### PR DESCRIPTION
**Background:**
Blurry outputs during up-scaling the video buffer, is a generic problem
of graphics industry. One of the major reason behind this blurriness is
the interpolation of pixel values used by most of the up-scaling hardware.

Nearest-neighbor is a scaling filter type, which works by filling in the
missing color values in the up-scaled image with that of the coordinate-mapped
nearest source pixel value.

Nearest-neighbor can produce (almost) non-blurry scaling outputs when
the scaling ratio is complete integer. For example:

input buffer resolution: 1280x720(HD)
output buffer resolution: 3840x2160(UHD/4K)
scaling ratio (h) = 3840/1280 = 3
scaling ratio (v) = 2160/720 = 3
In such scenarios, we should try to pick Nearest-neighbor as scaling
method when possible.

**Some references:**

- https://tanalin.com/en/articles/integer-scaling/
- 
- https://www.reddit.com/r/nvidia/comments/9e27wk/its_2018_nvidia_wheres_integer_scaling/
- 
- http://www.zeus-software.com/forum/viewtopic.php?t=2065
- 
- https://forums.geforce.com/default/topic/844905/geforce-drivers/-feature-request-nonblurry-upscaling-at-integer-ratios/20/
- 
- https://forums.tomshardware.com/threads/does-anybody-have-a-good-solution-to-scale-1080p-onto-a-4k-monitor.3217086/
- 

**This patch series:**
To address this feature kernel driver exposes new CRTC/Plane property called
"SCALING_FILTER" and gives an option to userspace to set it based on the use
cases.
Kernel RFC can be found here: https://patchwork.freedesktop.org/series/73884/

This patchset add support for utilizing CRTC/Plane scaling filter property based on
client's usecase.

Currently used some hack to input resolution hard coded eg: 640x480 instead of setting based on the CRTC mode.

**Here are the patches details:**
Patch 1/3 --> Disable GL-Scaling to make sure that scalling is done in DE via DRM path
Patch 2/3 --> add scaling_filter property support at plane level
Patch 3/3 --> Hacked by hard coding the source resolution info

**Kindly help us do it properly w/o hacking the input resolutions.**
-------------------------------------------------------------------------------------
Here are some sample reference data for having Integer scaling with NN filter:

OS Res X | OS Res Y | Panel X | Panel Y | Aspected Scaled dest X | Aspected Scaled dest Y | Scaled ratio X | Scaled ratio Y | IS dest X | IS dest Y
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
640 | 480 | 3840 | 2160 | 2880 | 2160 | 6 | 4.5 | 2560 | 1920
800 | 600 | 3840 | 2160 | 2880 | 2160 | 3.6 | 3.6 | 2400 | 1800
1024 | 768 | 3840 | 2160 | 2880 | 2160 | 2.8125 | 2.8125 | 2048 | 1536
1280 | 720 | 3840 | 2160 | 3840 | 2160 | 3 | 3 | 3840 | 2160
1280 | 1024 | 3840 | 2160 | 2700 | 2160 | 2.1094 | 2.1094 | 2560 | 2048
1920 | 1080 | 3840 | 2160 | 3840 | 2160 | 2 | 2 | 3840 | 2160
1920 | 1200 | 3840 | 2160 | 3456 | 2160 | 1.8 | 1.8 | 1920 | 1200

Awaiting your reviews and what do you think on having Integer Scaling in Kodi. Thanks
-Sameer Lattannavar
