### PR TITLE
Multi windowing fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                           ${ADDON_XML_OUTPUTS}
                    COMMAND ${CMAKE_COMMAND} -DCORE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                                             -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
+                                            -DCORE_PLATFORM_NAME_LC="${CORE_PLATFORM_NAME_LC}"
                                             -DCORE_BUILD_DIR=${CORE_BUILD_DIR}
                                             -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
                                             -DARCH_DEFINES="${ARCH_DEFINES}"

--- a/tools/Linux/kodi.sh.in
+++ b/tools/Linux/kodi.sh.in
@@ -44,39 +44,13 @@ do
             LIBDIR="$2"
             shift; shift
             ;;
-        --windowing)
-            WINDOWING="$2"
-            echo "$SAVED_ARGS" | sed "s/--windowing[ ]*$2//g"
-            shift; shift
-            ;;
         *)
             shift
             ;;
     esac
 done
 
-# Note: by default only one of those binaries exists
-# To be able to select a different one, if has to be compiled specifically
-# Your distribution might provide extra packages for those
-if [ "$WINDOWING" = "auto" ]; then
-    # Wayland
-    if [ -n "$WAYLAND_DISPLAY" ] && [ -x $LIBDIR/${bin_name}/${bin_name}-wayland ]; then
-        KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-wayland
-    # X11
-    elif echo $DISPLAY | grep -qE ":[0-9]+" && [ -x $LIBDIR/${bin_name}/${bin_name}-x11 ]; then
-        KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-x11
-    # GBM/DRM
-    elif [ -z "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ] && [ -x $LIBDIR/${bin_name}/${bin_name}-gbm ]; then
-        KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-gbm
-    # Default kodi.bin
-    else
-        KODI_BINARY=${APP_BINARY}
-    fi
-elif [ -n "$WINDOWING" ]; then
-    KODI_BINARY=$LIBDIR/${bin_name}/${bin_name}-${WINDOWING}
-else
-    KODI_BINARY=${APP_BINARY}
-fi
+KODI_BINARY=${APP_BINARY}
 
 if [ ! -x ${KODI_BINARY} ]; then
     echo "Error: ${KODI_BINARY} not found"

--- a/xbmc/AppParamParser.cpp
+++ b/xbmc/AppParamParser.cpp
@@ -23,20 +23,8 @@
 #if defined(TARGET_LINUX)
 namespace
 {
-
-std::vector<std::string> availableWindowSystems = {
-#if defined(HAVE_WAYLAND)
-    "wayland",
-#endif
-#if defined(HAVE_X11)
-    "x11",
-#endif
-#if defined(HAVE_GBM)
-    "gbm",
-#endif
-};
-
-} // namespace
+std::vector<std::string> availableWindowSystems = CCompileInfo::GetAvailableWindowSystems();
+}// namespace
 #endif
 
 CAppParamParser::CAppParamParser()

--- a/xbmc/CompileInfo.cpp.in
+++ b/xbmc/CompileInfo.cpp.in
@@ -100,3 +100,8 @@ std::vector<ADDON::RepoInfo> CCompileInfo::LoadOfficialRepoInfos()
 
   return officialRepoInfos;
 }
+
+const std::vector<std::string> CCompileInfo::GetAvailableWindowSystems()
+{
+  return StringUtils::Split("@CORE_PLATFORM_NAME_LC@", ' ');
+}

--- a/xbmc/CompileInfo.h
+++ b/xbmc/CompileInfo.h
@@ -30,5 +30,6 @@ public:
   static const char* GetCopyrightYears();
   static std::string GetBuildDate();
   static const char* GetVersionCode();
+  static const std::vector<std::string> GetAvailableWindowSystems();
   static std::vector<ADDON::RepoInfo> LoadOfficialRepoInfos();
 };

--- a/xbmc/windowing/WindowSystemFactory.cpp
+++ b/xbmc/windowing/WindowSystemFactory.cpp
@@ -10,17 +10,18 @@
 
 using namespace KODI::WINDOWING;
 
-std::list<std::function<std::unique_ptr<CWinSystemBase>()>> CWindowSystemFactory::m_windowSystems;
+std::map<std::string, std::function<std::unique_ptr<CWinSystemBase>()>> CWindowSystemFactory::m_windowSystems;
 
-std::list<std::function<std::unique_ptr<CWinSystemBase>()>> CWindowSystemFactory::GetWindowSystems()
+std::map<std::string, std::function<std::unique_ptr<CWinSystemBase>()>> CWindowSystemFactory::GetWindowSystems()
 {
   return m_windowSystems;
 }
 
 void CWindowSystemFactory::RegisterWindowSystem(
+    const std::string windowSystem,
     std::function<std::unique_ptr<CWinSystemBase>()> createFunction)
 {
-  m_windowSystems.emplace_back(createFunction);
+  m_windowSystems.insert({{windowSystem, createFunction}});
 }
 
 void CWindowSystemFactory::ClearBufferObjects()

--- a/xbmc/windowing/WindowSystemFactory.h
+++ b/xbmc/windowing/WindowSystemFactory.h
@@ -12,6 +12,7 @@
 
 #include <functional>
 #include <list>
+#include <map>
 #include <memory>
 
 namespace KODI
@@ -22,12 +23,13 @@ namespace WINDOWING
 class CWindowSystemFactory
 {
 public:
-  static std::list<std::function<std::unique_ptr<CWinSystemBase>()>> GetWindowSystems();
-  static void RegisterWindowSystem(std::function<std::unique_ptr<CWinSystemBase>()> createFunction);
+  static std::function<std::unique_ptr<CWinSystemBase>()> GetWindowSystem(std::string name="default") { return m_windowSystems[name]; }
+  static std::map<std::string, std::function<std::unique_ptr<CWinSystemBase>()>> GetWindowSystems();
+  static void RegisterWindowSystem(std::string windowSystem, std::function<std::unique_ptr<CWinSystemBase>()> createFunction);
   static void ClearBufferObjects();
 
 private:
-  static std::list<std::function<std::unique_ptr<CWinSystemBase>()>> m_windowSystems;
+  static std::map<std::string, std::function<std::unique_ptr<CWinSystemBase>()>> m_windowSystems;
 };
 
 } // namespace WINDOWING

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -41,7 +41,7 @@ using namespace KODI::WINDOWING::X11;
 
 void CWinSystemX11GLContext::Register()
 {
-  KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
+  KODI::WINDOWING::CWindowSystemFactory::RegisterWindowSystem("x11", CreateWinSystem);
 }
 
 std::unique_ptr<CWinSystemBase> CWinSystemX11GLContext::CreateWinSystem()

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -82,6 +82,14 @@ CWinSystemGbm::CWinSystemGbm() :
 
 bool CWinSystemGbm::InitWindowSystem()
 {
+  const char* x11 = getenv("DISPLAY");
+  const char* wayland = getenv("WAYLAND_DISPLAY");
+  if (x11 || wayland)
+  {
+    CLog::Log(LOGDEBUG, "Running under a Window Manager");
+    return false;
+  }
+
   m_DRM = std::make_shared<CDRMAtomic>();
 
   if (!m_DRM->InitDrm())

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -36,7 +36,7 @@ CWinSystemGbmGLContext::CWinSystemGbmGLContext()
 
 void CWinSystemGbmGLContext::Register()
 {
-  CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
+  CWindowSystemFactory::RegisterWindowSystem("gbm", CreateWinSystem);
 }
 
 std::unique_ptr<CWinSystemBase> CWinSystemGbmGLContext::CreateWinSystem()

--- a/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandEGLContextGL.cpp
@@ -27,7 +27,7 @@ using namespace KODI::WINDOWING::WAYLAND;
 
 void CWinSystemWaylandEGLContextGL::Register()
 {
-  CWindowSystemFactory::RegisterWindowSystem(CreateWinSystem);
+  CWindowSystemFactory::RegisterWindowSystem("wayland", CreateWinSystem);
 }
 
 std::unique_ptr<CWinSystemBase> CWinSystemWaylandEGLContextGL::CreateWinSystem()


### PR DESCRIPTION
1.  cleans up kodi wrapper script
2.  refactors windowing init:

- don't rely on init order, every windowing system returns false if it's not supposed to run on current WM
- move availableWindowSystems to CompileInfo and use that in CApp and CAppParamParser
- fixes crashing when forcing an incorrect window system e.g. using --windowing=wayland on X11

Issues: Other platforms might need small changes to Windowing Registration, not tested